### PR TITLE
Add check to Mosyle for IdP local password sync

### DIFF
--- a/Apple/MDM Comparison Table.md
+++ b/Apple/MDM Comparison Table.md
@@ -744,7 +744,7 @@ Key
         <td>:x:</td>
         <td>:white_check_mark::heavy_dollar_sign:</td>
         <td>:white_check_mark::heavy_dollar_sign:</td>
-        <td></td>
+        <td>:white_check_mark::heavy_dollar_sign:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>


### PR DESCRIPTION
Mosyle advertises _Mosyle Auth 2_ on [their website](https://business.mosyle.com), which says it syncs local passwords with IdP.