### PR TITLE
add Zentral to the MDM table

### DIFF
--- a/Apple/MDM Comparison Table.md
+++ b/Apple/MDM Comparison Table.md
@@ -15,6 +15,7 @@ ___
         <td>Mosyle</td>
         <td>Addigy</td>
         <td>JumpCloud</td>
+        <td>Zentral MDM</td>
     </tr>
     <tr>
         <td>macOS - Local Agent</td>
@@ -25,6 +26,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
+        <td>:white_check_mark:(via Munki)</td>
     </tr>
     <tr>
         <td>macOS - Local Agent Binary commands</td>
@@ -33,6 +35,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
     </tr>
@@ -45,6 +48,7 @@ ___
         <td>:x:</td>
         <td>:white_check_mark: - Via Zapier</td>
         <td>:white_check_mark:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Email Alerts - Requires additional infrastructure</td>
@@ -55,6 +59,7 @@ ___
         <td>:x:</td>
         <td>:x:</td>
         <td>:white_check_mark:</td>
+        <td>:grey_exclamation: Needs SMTP relay server setup</td>
     </tr>
     <tr>
         <td>Outgoing Webhook</td>
@@ -65,6 +70,7 @@ ___
         <td>:x:</td>
         <td>:x:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Outgoing Webhook - Requires additional infra for Slack</td>
@@ -75,12 +81,14 @@ ___
         <td>:x:</td>
         <td>:x:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Email Alerts - Native</td>
         <td>Alerts</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
@@ -95,6 +103,7 @@ ___
         <td>:white_check_mark: Included with Fuse</td>
         <td>:white_check_mark: Additional cost</td>
         <td>:x:</td>
+        <td>:x:</td>
     </tr>
     <tr>
         <td>Self Service App - macOS</td>
@@ -105,6 +114,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark: (via Munki)</td>
     </tr>
     <tr>
         <td>Custom Apps - Content Distribution</td>
@@ -115,10 +125,12 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
+        <td>:x:</td>
     </tr>
     <tr>
         <td>ABM Apps (fka VPP)</td>
         <td>App Delivery</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
@@ -135,6 +147,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Custom Apps</td>
@@ -145,6 +158,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:grey_exclamation: Custom apps need external blob storage</td>
+        <td>:x:</td>
     </tr>
     <tr>
         <td>Self Service App - iOS</td>
@@ -153,6 +167,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
+        <td>:x:</td>
         <td>:x:</td>
         <td>:x:</td>
     </tr>
@@ -165,6 +180,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark: (DDM > macOS14)</td>
     </tr>
     <tr>
         <td>App Updates - iOS - Forced</td>
@@ -175,6 +191,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>App Updates - iOS - Self Service</td>
@@ -185,11 +202,13 @@ ___
         <td>:white_check_mark:</td>
         <td>:x:</td>
         <td>:x:</td>
+        <td>:x:</td>
     </tr>
     <tr>
         <td>App Updates - macOS - Forced</td>
         <td>App Update</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
@@ -205,6 +224,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>App Updates - iOS - Scheduled or Maintenance Window</td>
@@ -215,6 +235,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:x:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>App Updates - macOS - Scheduled or Maintenance Window</td>
@@ -225,6 +246,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>API</td>
@@ -233,6 +255,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark: Unconventional setup - all PUT methods; Limited Endpoints</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
     </tr>
@@ -245,12 +268,14 @@ ___
         <td>:x:</td>
         <td>:x:</td>
         <td>:x:</td>
+        <td>:x:</td>
     </tr>
     <tr>
         <td>Pre-Built Configs/Policies</td>
         <td>Configuration</td>
         <td>:x:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
@@ -265,6 +290,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Shared iPad support</td>
@@ -273,6 +299,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
+        <td>:x:</td>
         <td>:x:</td>
         <td>:x:</td>
     </tr>
@@ -285,11 +312,13 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:x:</td>
     </tr>
     <tr>
         <td>Custom Scripts (without pkg workaround)</td>
         <td>Configuration</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
@@ -305,6 +334,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>App Block List</td>
@@ -315,10 +345,12 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Configuration Profiles</td>
         <td>Configuration</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
@@ -335,6 +367,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Role-Based Apps, Controls, Automations (Blueprints)</td>
@@ -345,10 +378,12 @@ ___
         <td>:x:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>ABM Integration</td>
         <td>Enrollment</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
@@ -365,10 +400,12 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Zero-Touch Deployment</td>
         <td>Enrollment</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
@@ -385,6 +422,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Directory Integration - Google Workspace </td>
@@ -395,11 +433,13 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Admin Portal - SSO Login</td>
         <td>Identity</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
@@ -415,11 +455,13 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>macOS - SSO Login</td>
         <td>Identity</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
@@ -435,6 +477,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>macOS - Migration agent from old MDM</td>
@@ -445,6 +488,7 @@ ___
         <td>:x:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
+         <td>:white_check_mark: (via umad)</td>
     </tr>
     <tr>
         <td>OS Updates - iOS/mobile</td>
@@ -453,6 +497,7 @@ ___
         <td>:x:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
     </tr>
@@ -465,6 +510,7 @@ ___
         <td>:x:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>OS Updates - mac - Managed (pre-configured)</td>
@@ -473,6 +519,7 @@ ___
         <td>:x:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
     </tr>
@@ -485,11 +532,13 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Auditor access</td>
         <td>RBAC - Roles</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
@@ -505,6 +554,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Reporting - Custom</td>
@@ -515,6 +565,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Built-In - Local Admin Password Solution (LAPS)</td>
@@ -524,6 +575,7 @@ ___
         <td>:x: pw can be manually changed, but no way to retrieve pw without custom script to write pw to log file</td>
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
+        <td>:x:</td>
         <td>:x:</td>
     </tr>
     <tr>
@@ -535,6 +587,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Compliance Control</td>
@@ -545,6 +598,7 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
     <tr>
         <td>Security Templates</td>
@@ -555,5 +609,6 @@ ___
         <td>:white_check_mark:</td>
         <td>:white_check_mark:</td>
         <td>:x:</td>
+        <td>:white_check_mark:</td>
     </tr>
 </table>


### PR DESCRIPTION
As discussed during Macadminsmonthly a few weeks ago, the table extension for [Zentral](https://github.com/zentralopensource/zentral) with our Zentral.com services / SLA option.